### PR TITLE
Upgraded helm version to 2.8.0 also updated maintainer field with label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 
-MAINTAINER Lachlan Evenson <lachlan.evenson@gmail.com>
+LABEL maintainer="Lachlan Evenson <lachlan.evenson@gmail.com>"
 
 ARG VCS_REF
 ARG BUILD_DATE
@@ -11,7 +11,7 @@ LABEL org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.docker.dockerfile="/Dockerfile"
 
-ENV HELM_LATEST_VERSION="v2.7.2"
+ENV HELM_LATEST_VERSION="v2.8.0"
 
 RUN apk add --update ca-certificates \
  && apk add --update -t deps wget \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.docker.dockerfile="/Dockerfile"
 
-ENV HELM_LATEST_VERSION="v2.8.0"
+ENV HELM_LATEST_VERSION="v2.7.2"
 
 RUN apk add --update ca-certificates \
  && apk add --update -t deps wget \


### PR DESCRIPTION
Hi,
  Awesome work! I have been this image extensively throughout our CI/CD pipeline. Recently [HELM 2.8.0](https://github.com/kubernetes/helm/releases/tag/v2.8.0) was released with K8s 1.9 support. 