### PR TITLE
Fix missing packages for helm plugin install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ LABEL org.label-schema.vcs-ref=$VCS_REF \
 ENV HELM_LATEST_VERSION="v2.12.3"
 
 RUN apk add --update ca-certificates \
- && apk add --update -t deps wget \
+ && apk add --update -t deps wget git openssl bash \
  && wget https://storage.googleapis.com/kubernetes-helm/helm-${HELM_LATEST_VERSION}-linux-amd64.tar.gz \
  && tar -xvf helm-${HELM_LATEST_VERSION}-linux-amd64.tar.gz \
  && mv linux-amd64/helm /usr/local/bin \


### PR DESCRIPTION
Hello,

In order to install helm plugin from github we need some packages to be installed

Example is the S3 plugin

```
helm plugin install https://github.com/hypnoglow/helm-s3.git --version 0.8.0
```

Regards,