### PR TITLE
Add Client only flag to test step.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,4 @@ docker_push:
 	docker push $(DOCKER_IMAGE):$(DOCKER_TAG)
 
 test:
-	docker run $(DOCKER_IMAGE):$(DOCKER_TAG) version
+	docker run $(DOCKER_IMAGE):$(DOCKER_TAG) version -c


### PR DESCRIPTION
Currently, the build for version 2.17.0 is failing since it is not able to communicate with a working server during the test step.

This change adds a `-c` flag in order to stop helm from attempting to communicate with a live server.

Behavior without `-c`: 
```
docker run lachlanevenson/k8s-helm:v2.17.0 version
Client: &version.Version{SemVer:"v2.17.0", GitCommit:"a690bad98af45b015bd3da1a41f6218b1a451dbe", GitTreeState:"clean"}
Error: Get "http://localhost:8080/api/v1/namespaces/kube-system/pods?labelSelector=app%3Dhelm%2Cname%3Dtiller": dial tcp 127.0.0.1:8080: connect: connection refused
```

Behavior with `-c`: 
```
docker run lachlanevenson/k8s-helm:v2.17.0 version -c
Client: &version.Version{SemVer:"v2.17.0", GitCommit:"a690bad98af45b015bd3da1a41f6218b1a451dbe", GitTreeState:"clean"}
```
