### PR TITLE
Build multi-arch k8s-helm image

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -11,24 +11,37 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Build Helm container
-      uses: docker/build-push-action@v1
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: lachlanevenson/k8s-helm
-        add_git_labels:  true
-        tag_with_ref: true
-        push: false
-    - name: Test Helm container
-      run: GIT_BRANCH=${GITHUB_REF#refs/heads/} make test
-    - name: Publish Helm container
+    - name: Build and test Helm container
+      run: |
+        GIT_BRANCH=${GITHUB_REF#refs/heads/} make docker_build
+        GIT_BRANCH=${GITHUB_REF#refs/heads/} make test
+    - name: Docker meta
       if: ${{ startsWith(github.ref, 'refs/heads/m') || startsWith(github.ref, 'refs/heads/v') }}
-      uses: docker/build-push-action@v1
+      id: docker_meta
+      uses: crazy-max/ghaction-docker-meta@v1
+      with:
+        images: lachlanevenson/k8s-helm
+        tag-semver: |
+          {{raw}}
+    - name: Set up QEMU
+      if: ${{ startsWith(github.ref, 'refs/heads/m') || startsWith(github.ref, 'refs/heads/v') }}
+      uses: docker/setup-qemu-action@v1
+    - name: Set up Docker Buildx
+      if: ${{ startsWith(github.ref, 'refs/heads/m') || startsWith(github.ref, 'refs/heads/v') }}
+      uses: docker/setup-buildx-action@v1
+    - name: Login to DockerHub
+      if: ${{ startsWith(github.ref, 'refs/heads/m') || startsWith(github.ref, 'refs/heads/v') }}
+      uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: lachlanevenson/k8s-helm
-        tag_with_ref: true
-        add_git_labels:  true
+    - name: Build and publish multi-arch Helm container
+      if: ${{ startsWith(github.ref, 'refs/heads/m') || startsWith(github.ref, 'refs/heads/v') }}
+      uses: docker/build-push-action@v2
+      with:
+        platforms: linux/amd64,linux/s390x,linux/arm64,linux/ppc64le
         push: true
+        tags: |
+          ${{ github.ref != 'refs/heads/master' && steps.docker_meta.outputs.tags || '' }}
+          ${{ github.ref == 'refs/heads/master' && 'lachlanevenson/k8s-helm:latest' || '' }}
+        labels: ${{ steps.docker_meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,14 +8,17 @@ LABEL org.opencontainers.image.title="lachlanevenson/k8s-helm" \
 
 ENV HELM_LATEST_VERSION="v3.5.0"
 
+ARG TARGETARCH
+ENV TARGETARCH=${TARGETARCH:-amd64}
+
 RUN apk add --update ca-certificates \
  && apk add --update -t deps wget git openssl bash \
- && wget -q https://get.helm.sh/helm-${HELM_LATEST_VERSION}-linux-amd64.tar.gz \
- && tar -xf helm-${HELM_LATEST_VERSION}-linux-amd64.tar.gz \
- && mv linux-amd64/helm /usr/local/bin \
+ && wget -q https://get.helm.sh/helm-${HELM_LATEST_VERSION}-linux-${TARGETARCH}.tar.gz \
+ && tar -xf helm-${HELM_LATEST_VERSION}-linux-${TARGETARCH}.tar.gz \
+ && mv linux-${TARGETARCH}/helm /usr/local/bin \
  && apk del --purge deps \
  && rm /var/cache/apk/* \
- && rm -f /helm-${HELM_LATEST_VERSION}-linux-amd64.tar.gz
+ && rm -f /helm-${HELM_LATEST_VERSION}-linux-${TARGETARCH}.tar.gz
 
 ENTRYPOINT ["helm"]
 CMD ["help"]


### PR DESCRIPTION
Use multi-arch build github actions for helm image, see https://github.com/docker/build-push-action#multi-platform-image
to get multi-arch image for `linux/amd64`, `linux/arm64`, `linux/s390x`, `linux/ppc64le` architectures
- replacement of `docker/build-push-action@v1` to `docker/build-push-action@v2` to build multi-arch images
- use extra `crazy-max/ghaction-docker-meta@v1` action to get labels and tags, see https://github.com/docker/build-push-action#handle-tags-and-labels

Also use docker buildx env variable(`TARGETARCH`) to properly identify target arch in
the Dockerfile https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
amd64  is still default one and pure `docker build` will be done without any extra steps.

See Github action logs for master branch of fork repo [here](https://github.com/barthy1/k8s-helm/runs/1854793759?check_suite_focus=true).